### PR TITLE
fix: ready for igor/contractnet

### DIFF
--- a/.env.igor
+++ b/.env.igor
@@ -1,0 +1,19 @@
+# These are the values for all tariswap-related templates and addreses deployed currently in ContractNet
+
+# Template address of the fungible faucet (TestFaucet)
+VITE_FAUCET_TEMPLATE=5722790c41c424a3d34ae136afaf6e1cba129f1137821acfcb1e9541a84be0f4
+
+# Template address of the pool (TariswapPool)
+VITE_POOL_TEMPLATE=e6aae2a9b8beb5f48e710ed3fa48e7ae67d98df781a8d038b7b273dad8391dc9
+
+# Template address of the pool index (TariswapIndex)
+VITE_POOL_INDEX_TEMPLATE=e1d7b0a49f8945093520f3890bf40c34b08c681785d569c6116d0fb3edd6f463
+
+# Component address of the pool index
+VITE_POOL_INDEX_COMPONENT=component_312eb06f08285a021869245fbedd37ab17f0a48ff98cf91222e5d8426a5442f0
+
+# Wallet connect project id
+VITE_WALLET_CONNECT_PROJECT_ID=78f3485d08b9640a087cbcea000e1f8b
+
+# Tari network id
+VITE_NETWORK=36

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ The `tariswap` template implements a decentralized exchange smart contract on th
 
 ## Install templates
 
-We need a running Tari network with the following:
-* Both `tariswap_index` and `tariswap_pool` templates deployed. The code can be found in the Tari [test-templates](https://github.com/tari-project/test-templates/tree/main/templates/tariswap/templates) repository.
-* The `faucet` template deployed. It can be found in the Tari [template_test_tooling](https://github.com/tari-project/tari-dan/tree/development/dan_layer/template_test_tooling/templates/faucet) crate.
+We need a running Tari network with the following templates:
+* `tariswap_index`
+* `tariswap_pool`
+* `faucet`
+
+The template code as well as the binaries (WASM files) can be found in the Tari [test-templates](https://github.com/tari-project/test-templates/tree/main/templates/tariswap/templates) repository.
 
 If you plan to use `ContractNet`, most likely these templates are already deployed.
 Otherwise, you will need to build WASM templates and upload them to Tari chain using one of many available methods. One of them is using Tari Wallet `Publish Template` feature.

--- a/src/tariswap.ts
+++ b/src/tariswap.ts
@@ -67,7 +67,7 @@ export async function listPools(
 ): Promise<PoolProps[]> {
   const substate = await wallet.getSubstate(provider, poolIndexComponent);
 
-  const state = cbor.convertCborValue(substate.value.substate.Component.body.state);
+  const state = cbor.convertCborValue(substate.value.Component.body.state);
   const pools = state["pools"] as Record<string, string> | undefined;
   if (!pools) {
     return [];
@@ -85,7 +85,7 @@ export async function getPoolLiquidityResource(
 ) {
   const substate = await wallet.getSubstate(provider, poolComponent);
 
-  const componentBody = substate.value.substate.Component.body.state;
+  const componentBody = substate.value.Component.body.state;
   const lpResource = cbor.getValueByPath(componentBody, "$.lp_resource");
 
   return lpResource;


### PR DESCRIPTION
* Added an `.env.igor` file with the current template/component addresses ready to use for Igor (i.e. ContractNet)
* Fixed invalid object paths when inspecting substates for the pool/liquidity display
* Updated README to point the `faucet` template to the same repo as the other templates